### PR TITLE
In Unity 2017+, cache material property IDs to improve performance

### DIFF
--- a/MCS_Core/Constants.cs
+++ b/MCS_Core/Constants.cs
@@ -103,10 +103,65 @@ namespace MCS.CONSTANTS
         [Description("Never recalculate mesh boundaries")]
         NEVER
     }
-
 }
 
+public static class MaterialConstants
+{
+#if UNITY_TARGET_GTE_2017
 
+    // In Unity 2017+ we can easily cache the internal material property IDs to improve performance.
+
+    // Texture Properties
+    public static readonly int MainTexPropID = Shader.PropertyToID("_MainTex");
+    public static readonly int MetallicGlossMapPropID = Shader.PropertyToID("_MetallicGlossMap");
+    public static readonly int ParallaxMapPropID = Shader.PropertyToID("_ParallaxMap");
+    public static readonly int BumpMapPropID = Shader.PropertyToID("_BumpMap");
+    public static readonly int DetailNormalMapPropID = Shader.PropertyToID("_DetailNormalMap");
+    public static readonly int SpecGlossMapPropID = Shader.PropertyToID("_SpecGlossMap");
+    public static readonly int EmissionMapPropID = Shader.PropertyToID("_EmissionMap");
+    public static readonly int AlphaTexPropID = Shader.PropertyToID("_AlphaTex");
+    public static readonly int OverlayPropID = Shader.PropertyToID("_Overlay");
+
+    // Color Properties
+    public static readonly int ColorPropID = Shader.PropertyToID("_Color");
+    public static readonly int EmissionColorPropID = Shader.PropertyToID("_EmissionColor");
+    public static readonly int OverlayColorPropID = Shader.PropertyToID("_OverlayColor");
+
+    // Float Properties
+    public static readonly int DetailNormalMapScalePropID = Shader.PropertyToID("_DetailNormalMapScale");
+
+#else
+
+    // Texture Properties
+    public const string MainTexPropID = "_MainTex";
+    public const string MetallicGlossMapPropID = "_MetallicGlossMap";
+    public const string ParallaxMapPropID = "_ParallaxMap";
+    public const string BumpMapPropID = "_BumpMap";
+    public const string DetailNormalMapPropID = "_DetailNormalMap";
+    public const string SpecGlossMapPropID = "_SpecGlossMap";
+    public const string EmissionMapPropID = "_EmissionMap";
+    public const string AlphaTexPropID = "_AlphaTex";
+    public const string OverlayPropID = "_Overlay";
+
+    // Color Properties
+    public const string ColorPropID = "_Color";
+    public const string EmissionColorPropID = "_EmissionColor";
+    public const string OverlayColorPropID = "_OverlayColor";
+
+    // Float Properties
+    public const string DetailNormalMapScalePropID = "_DetailNormalMapScale";
+
+#endif
+
+    // Shader Keyword Constants
+    public const string METALLICGLOSSMAP_KEYWORD = "_METALLICGLOSSMAP";
+    public const string PARALLAXMAP_KEYWORD = "_PARALLAXMAP";
+    public const string NORMALMAP_KEYWORD = "_NORMALMAP";
+    public const string DETAIL_MULX2_KEYWORD = "_DETAIL_MULX2";
+    public const string SPECGLOSSMAP_KEYWORD = "_SPECGLOSSMAP";
+    public const string EMISSION_KEYWORD = "_EMISSION";
+    public const string OVERLAY_KEYWORD = "_OVERLAY";
+}
 
 public static class EnumHelper
 {

--- a/MCS_Core/ContentLibrary/AssetCreator.cs
+++ b/MCS_Core/ContentLibrary/AssetCreator.cs
@@ -178,31 +178,31 @@ namespace M3D_DLL
 
 
             if (textures.ContainsKey ("albedo")) {
-				material.SetTexture ("_MainTex", textures["albedo"]);
+				material.SetTexture (MaterialConstants.MainTexPropID, textures["albedo"]);
 			}
 			if (textures.ContainsKey ("metal")) {
-				material.SetTexture ("_MetallicGlossMap", textures["metal"]);
-                material.EnableKeyword("_METALLICGLOSSMAP");
+				material.SetTexture (MaterialConstants.MetallicGlossMapPropID, textures["metal"]);
+                material.EnableKeyword(MaterialConstants.METALLICGLOSSMAP_KEYWORD);
 			}
 			if (textures.ContainsKey ("height")) {
-				material.SetTexture ("_ParallaxMap", textures["height"]);
-                material.EnableKeyword("_PARALLAXMAP");
+				material.SetTexture (MaterialConstants.ParallaxMapPropID, textures["height"]);
+                material.EnableKeyword(MaterialConstants.PARALLAXMAP_KEYWORD);
 			}
 			if (textures.ContainsKey ("normal")) {
-				material.SetTexture ("_BumpMap", textures["normal"]);
-                material.EnableKeyword("_NORMALMAP");
+				material.SetTexture (MaterialConstants.BumpMapPropID, textures["normal"]);
+                material.EnableKeyword(MaterialConstants.NORMALMAP_KEYWORD);
 			}
 			if (textures.ContainsKey ("detail_normal")) {
-				material.SetTexture ("_DetailNormalMap", textures["detail_normal"]);
-                material.EnableKeyword("_DETAIL_MULX2");
+				material.SetTexture (MaterialConstants.DetailNormalMapPropID, textures["detail_normal"]);
+                material.EnableKeyword(MaterialConstants.DETAIL_MULX2_KEYWORD);
 			}
 			if (textures.ContainsKey ("specular")) {
-				material.SetTexture ("_SpecGlossMap", textures["specular"]);
-                material.EnableKeyword("_SPECGLOSSMAP");
+				material.SetTexture (MaterialConstants.SpecGlossMapPropID, textures["specular"]);
+                material.EnableKeyword(MaterialConstants.SPECGLOSSMAP_KEYWORD);
 			}
 			if (textures.ContainsKey ("emission")) {
-				material.SetTexture ("_EmissionMap", textures["emission"]);
-                material.EnableKeyword("_EMISSION");
+				material.SetTexture (MaterialConstants.EmissionMapPropID, textures["emission"]);
+                material.EnableKeyword(MaterialConstants.EMISSION_KEYWORD);
 			}
 
             /*
@@ -216,16 +216,16 @@ namespace M3D_DLL
 
 			if (!String.IsNullOrEmpty(schematic.structure_and_physics.material_structure.albedo_tint)) {
                 Color c = AssetSchematicUtility.ConvertColorStringToColor(schematic.structure_and_physics.material_structure.albedo_tint);
-                material.SetColor ("_Color", c);
+                material.SetColor (MaterialConstants.ColorPropID, c);
 			}
             if (!String.IsNullOrEmpty(schematic.structure_and_physics.material_structure.emission_value))
             {
                 Color c = AssetSchematicUtility.ConvertColorStringToColor(schematic.structure_and_physics.material_structure.emission_value);
-                material.SetColor("_EmissionColor", c);
+                material.SetColor(MaterialConstants.EmissionColorPropID, c);
             }
-            if (material.HasProperty("_DetailNormalMapScale") && schematic.structure_and_physics.material_structure.detail_normal_value>0f)
+            if (material.HasProperty(MaterialConstants.DetailNormalMapScalePropID) && schematic.structure_and_physics.material_structure.detail_normal_value>0f)
             {
-                material.SetFloat("_DetailNormalMapScale", schematic.structure_and_physics.material_structure.detail_normal_value);
+                material.SetFloat(MaterialConstants.DetailNormalMapScalePropID, schematic.structure_and_physics.material_structure.detail_normal_value);
             }
 
             if (schematic.structure_and_physics.material_structure.shader_keywords != null)
@@ -275,8 +275,6 @@ namespace M3D_DLL
                         default:
                             UnityEngine.Debug.Log("Invalid material property: " + schematic.origin_and_description.name + " => " + schematic.origin_and_description.mcs_id + " key: " + key);
                             throw new Exception("Invalid shader property");
-                            break;
-
                     }
                 }
             }

--- a/MCS_Core/CoreServices/AlphaInjectionManager.cs
+++ b/MCS_Core/CoreServices/AlphaInjectionManager.cs
@@ -520,7 +520,7 @@ namespace MCS.CORESERVICES
             for (int i = 0; i < materials.Length; i++)
             {
 
-                if (materials[i] == null || !materials[i].HasProperty("_AlphaTex"))
+                if (materials[i] == null || !materials[i].HasProperty(MaterialConstants.AlphaTexPropID))
                 {
                     continue;
                 }
@@ -567,7 +567,7 @@ namespace MCS.CORESERVICES
                             //uncomment if you want to debug the masks
                             //TextureUtilities.OverlayArrayOfTexturesGPU(ref tex, masks,"Unlit/AlphaCombiner",true);
                             temporaryTexture2D.Add(tex);
-                            materials[i].SetTexture("_AlphaTex", tex);
+                            materials[i].SetTexture(MaterialConstants.AlphaTexPropID, tex);
 
                             break;
                         case TEXTURE_MODE.FASTEST:
@@ -575,17 +575,17 @@ namespace MCS.CORESERVICES
                             //rt = TextureUtilities.OverlayArrayOfTexturesGPU(masks, "Unlit/AlphaCombiner", true);
                             temporaryRenderTextures[i] = rt;
                             //UnityEngine.Debug.Log("Assigning rt: " + smr.name + " | " + slot);
-                            materials[i].SetTexture("_AlphaTex", rt);
+                            materials[i].SetTexture(MaterialConstants.AlphaTexPropID, rt);
                             break;
                     }
                 } else
                 {
                     //no textures, clear it
-                    materials[i].SetTexture("_AlphaTex", null);
+                    materials[i].SetTexture(MaterialConstants.AlphaTexPropID, null);
                 }
 
                 /*
-                RenderTexture rtOld = materials[i].GetTexture("_AlphaTex") as RenderTexture;
+                RenderTexture rtOld = materials[i].GetTexture(MaterialIDs.AlphaTexMatID) as RenderTexture;
                 if(rtOld != null)
                 {
                     RenderTexture.Destroy(rtOld);
@@ -594,7 +594,7 @@ namespace MCS.CORESERVICES
 
                 //UnityEngine.Debug.Log("Drawing Alpha: " + materials[i].name + " | " + materials.Length + " | " + (masks != null ? masks.Length.ToString() : "null") + " | " + slot + " | " + (tex != null ? "Tex is not null" : "tex is null"));
                 //install the texture
-                //materials[i].SetTexture("_AlphaTex", tex);
+                //materials[i].SetTexture(MaterialIDs.AlphaTexMatID, tex);
             }
 
             if (Application.isPlaying)

--- a/MCS_Core/Costuming/CIhair.cs
+++ b/MCS_Core/Costuming/CIhair.cs
@@ -152,25 +152,25 @@ namespace MCS.COSTUMING
             {
                 tmpOverlay = null;
                 tmpOverlayColor = Color.clear;
-                headMat.DisableKeyword("_OVERLAY");
+                headMat.DisableKeyword(MaterialConstants.OVERLAY_KEYWORD);
             } else
             {
                 if (tmpOverlay != null || tmpOverlayColor.a > 0)
                 {
-                    headMat.EnableKeyword("_OVERLAY");
+                    headMat.EnableKeyword(MaterialConstants.OVERLAY_KEYWORD);
                 } else
                 {
-                    headMat.DisableKeyword("_OVERLAY");
+                    headMat.DisableKeyword(MaterialConstants.OVERLAY_KEYWORD);
                 }
             }
 
-            if (headMat.HasProperty("_Overlay"))
+            if (headMat.HasProperty(MaterialConstants.OverlayPropID))
             {
-                headMat.SetTexture("_Overlay", tmpOverlay);
+                headMat.SetTexture(MaterialConstants.OverlayPropID, tmpOverlay);
             }
-            if(headMat.HasProperty("_OverlayColor"))
+            if(headMat.HasProperty(MaterialConstants.OverlayColorPropID))
             {
-                headMat.SetColor("_OverlayColor", tmpOverlayColor);
+                headMat.SetColor(MaterialConstants.OverlayColorPropID, tmpOverlayColor);
             }
         }
 
@@ -199,16 +199,16 @@ namespace MCS.COSTUMING
             Texture tmpOverlay = null;
             Color tmpOverlayColor = Color.clear;
 
-            if (headMat.HasProperty("_Overlay"))
+            if (headMat.HasProperty(MaterialConstants.OverlayPropID))
             {
-                headMat.SetTexture("_Overlay", tmpOverlay);
+                headMat.SetTexture(MaterialConstants.OverlayPropID, tmpOverlay);
             }
-            if(headMat.HasProperty("_OverlayColor"))
+            if(headMat.HasProperty(MaterialConstants.OverlayColorPropID))
             {
-                headMat.SetColor("_OverlayColor", tmpOverlayColor);
+                headMat.SetColor(MaterialConstants.OverlayColorPropID, tmpOverlayColor);
             }
 
-            headMat.DisableKeyword("_OVERLAY");
+            headMat.DisableKeyword(MaterialConstants.OVERLAY_KEYWORD);
         }
 
 		private void FindAndSyncCap(){

--- a/MCS_Core/MCSCharacterManager.cs
+++ b/MCS_Core/MCSCharacterManager.cs
@@ -1605,10 +1605,10 @@ namespace MCS
             {
                 return;
             }
-            if (material.HasProperty("_Overlay"))
+            if (material.HasProperty(MaterialConstants.OverlayPropID))
             {
-                material.SetTexture("_Overlay", null);
-                material.DisableKeyword("_OVERLAY");
+                material.SetTexture(MaterialConstants.OverlayPropID, null);
+                material.DisableKeyword(MaterialConstants.OVERLAY_KEYWORD);
             }
         }
         /// <summary>
@@ -1620,17 +1620,17 @@ namespace MCS
         public void InstallOverlay(Texture2D texture,Color color)
         {
             return;
-            if(texture == null)
-            {
-                return;
-            }
-            Material material = GetHairMaterial();
-            if (material.HasProperty("_Overlay"))
-            {
-                material.SetTexture("_Overlay", texture);
-                material.SetColor("_OverlayColor", color);
-                material.EnableKeyword("_OVERLAY");
-            }
+            //if(texture == null)
+            //{
+            //    return;
+            //}
+            //Material material = GetHairMaterial();
+            //if (material.HasProperty(MaterialIDs.OverlayMatID))
+            //{
+            //    material.SetTexture(MaterialIDs.OverlayMatID, texture);
+            //    material.SetColor(MaterialIDs.OverlayColorMatID, color);
+            //    material.EnableKeyword("_OVERLAY");
+            //}
         }
 
         /// <summary>

--- a/MCS_Utilities/MorphExtraction/MorphExtraction.cs
+++ b/MCS_Utilities/MorphExtraction/MorphExtraction.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using UnityEditor;
 using System;
 using System.Collections;
 using System.Collections.Generic;


### PR DESCRIPTION
In Unity 2017+ we can easily cache material property IDs to have some extra performance. In previous Unity versions that can also be done, but _Shader.PropertyToID_ method can only be called from an _Awake()_ or _Start()_ event, so I wasn't sure where I should add the call. Besides, there is the possibility of not working outside Play mode too.

So right now, all material property gets and sets work exactly as before, but if someone wants to target Unity 2017+, setting the _UNITY_TARGET_GTE_2017_ conditional compilation symbol will allow this performance benefit.

Shader keywords are also conveniently grouped in constants.